### PR TITLE
fix aoj sample test html header number

### DIFF
--- a/onlinejudge/service/aoj.py
+++ b/onlinejudge/service/aoj.py
@@ -97,7 +97,7 @@ class AOJProblem(onlinejudge.type.Problem):
             soup = bs4.BeautifulSoup(html, utils.HTML_PARSER)
             for pre in soup.find_all('pre'):
                 tag = pre.find_previous_sibling()
-                if tag and tag.name == 'h3' and tag.string and any(s in tag.string for s in expected_strings):
+                if tag and tag.name == 'h2' and tag.string and any(s in tag.string for s in expected_strings):
                     s = utils.textfile(utils.parse_content(pre).lstrip())
                     zipper.add(s.encode(), tag.string)
             samples = zipper.get()


### PR DESCRIPTION
サンプルケースのデータが提供されていない問題で、ページを parse する場合でもエラーにならなくなった

`python -m pip install .`


```
oj-api get-problem https://onlinejudge.u-aizu.ac.jp/courses/library/3/DSL/all/DSL_2_I | jq .
INFO:onlinejudge_api.main:online-judge-api-client 10.10.1
INFO:onlinejudge_api.main:sleep 1.000000 sec
INFO:onlinejudge.utils:load cookie from: /home/ubuntu/.local/share/online-judge-tools/cookie.jar
INFO:onlinejudge._implementation.utils:network: GET: https://judgedat.u-aizu.ac.jp/testcases/samples/DSL_2_I
INFO:onlinejudge._implementation.utils:network: 200 OK
WARNING:onlinejudge.service.aoj:sample cases are not registered in the official API
INFO:onlinejudge.service.aoj:fallback: parsing HTML
INFO:onlinejudge._implementation.utils:network: GET: https://judgeapi.u-aizu.ac.jp/resources/descriptions/ja/DSL_2_I
INFO:onlinejudge._implementation.utils:network: 200 OK
INFO:onlinejudge.utils:save cookie to: /home/ubuntu/.local/share/online-judge-tools/cookie.jar
{
  "status": "ok",
  "messages": [],
  "result": {
    "url": "http://judge.u-aizu.ac.jp/onlinejudge/description.jsp?id=DSL_2_I",
    "tests": [
      {
        "input": "6 7\n0 1 3 1\n0 2 4 -2\n1 0 5\n1 0 1\n0 3 5 3\n1 3 4\n1 0 5\n",
        "output": "-5\n1\n6\n8\n"
      }
    ],
    "context": {}
  }
}
```